### PR TITLE
Patch post job api 401 Unauthorized error

### DIFF
--- a/client/src/features/jobStore/jobAPI.js
+++ b/client/src/features/jobStore/jobAPI.js
@@ -2,18 +2,17 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 const baseUrl = import.meta.env.VITE_SERVER_BASE_URL;
 const port = import.meta.env.VITE_SERVER_PORT;
 
-const storedUser = JSON.parse(sessionStorage.getItem("loggedUser"));
 // const token = storedUser ? storedUser.token : null;
 
 const getToken = () => {
-  const tokenString = localStorage.getItem("token");
+  const storedUser = JSON.parse(sessionStorage.getItem("loggedUser"));
+  console.log("storedUser: ", storedUser);
+  const token = storedUser.token;
 
-  if (tokenString) {
-    // Parse the JSON string back to its original format (string)
-    const token = JSON.parse(tokenString);
+  if (token) {
     return token; // Return the token string
   }
-  return null; // Return null if the token isn't found // Example: Get the token from local storage
+  return null; // Return null if the token isn't found // Example: Get the token from session storage
 };
 
 // console.log(token);


### PR DESCRIPTION
token used to be retrieved from localStorage which -from the looks of it- is not being updated. 
* in Job-API the token being sent is the one saved in the sessionStorage (which is updated and works as expected).
-- I recommend checking the localStorage token and making sure it is updated correctly 